### PR TITLE
Gebruik dezelfde versie als in de specificatie staat

### DIFF
--- a/swagger/doorstroom-openapi.yaml
+++ b/swagger/doorstroom-openapi.yaml
@@ -57,7 +57,7 @@ paths:
                 value:
                   datumtijd: 2023-05-10T11:44:00Z
                   auteur: Applicatie xyz
-                  versie: Doorstroomtoetsketen_v1
+                  versie: Doorstroomtoetsketen_v1.0
                   profiel: Toetsdeelnemers
                   schooljaar: 2023-2024
                   deelnemersgroep:
@@ -94,7 +94,7 @@ paths:
                 value:
                   datumtijd: 2023-05-10T11:44:00Z
                   auteur: Applicatie xyz
-                  versie: Doorstroomtoetsketen_v1
+                  versie: Doorstroomtoetsketen_v1.0
                   profiel: Toetsdeelnemers
                   schooljaar: 2023-2024
                   deelnemersgroep:
@@ -214,7 +214,7 @@ paths:
                 value:
                   datumtijd: 2023-05-10T11:44:00Z
                   auteur: Toetssysteem xyz
-                  versie: Doorstroomtoetsketen_v1
+                  versie: Doorstroomtoetsketen_v1.0
                   profiel: Leerlingtoetsresultaat
                   schooljaar: 2023-2024
                   resultatenscores:


### PR DESCRIPTION
In de specificatie staat dat de enige toegestane versie van het document `Doorstroomtoetsketen_v1.0` is. In de Swagger-voorbeelden voor het aanleveren van leerlingen stond echter `Doorstroomtoetsketen_v1`. Dit lijkt voldoende op elkaar om verwarring te veroorzaken. Als de specificatie met een schuin oog doorgelezen wordt, dan onthou je vooral de concepten. Vervolgens ga je de interface implementeren. Daarbij wilde je even naslaan wat het al was en kijk je in de Swagger. Dit komt overeen met wat je je meent te herinneren en je neemt het over.

Om dit te voorkomen, is het fijn dat de voorbeelden consistent zijn met de specificatie.